### PR TITLE
Small typo-fix and replacing manual counting with ordered list from markdown in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ What's the catch?
 
 How to use Nemesis for users?
 1. If this is your first time running Nemesis, click Update Engine to install the latest engine version
-2. After updating the engine, check the mod you are using in the box
-3. Click Launch Nemesis Unlimited Behavior Engine to generate behavior files
-4. Launch skyrim
+1. After updating the engine, check the mod you are using in the box
+1. Click Launch Nemesis Unlimited Behavior Engine to generate behavior files
+1. Launch skyrim
 
 Youtube tutorial on how to use Nemesis: https://www.youtube.com/watch?v=mug-KFBwJTo
 
@@ -51,33 +51,33 @@ Build requirement for developers:
 
 How to build Nemesis for developers:
 1. Download and install Qt5
-2. Download and install boost
-3. Download Python 3.5.6
-4. Open NemesisEngine.sln
-5. Go to Project Properties -> C++ -> General -> Additional Include Directories, update the boost and python directories
-6. Go to Project Properties -> Linker -> General -> Additional Library Directories, update the boost and python directories
-7. Build
-8. Test your build in "test environment"
+1. Download and install boost
+1. Download Python 3.5.6
+1. Open NemesisEngine.sln
+1. Go to Project Properties -> C++ -> General -> Additional Include Directories, update the boost and python directories
+1. Go to Project Properties -> Linker -> General -> Additional Library Directories, update the boost and python directories
+1. Build
+1. Test your build in "test environment"
 
 
 Before you open an issue
 1. research the issue, see if there is any similar issue has been reported
-2. remove all mods except essential mods to duplicate the issues as well as SKSE and alternate start and try to recreate the issue under this setup
-3. TUDM dodge not working? Are you using alternate start? if yes, get out of the cell
-4. Test test test. Make sure it is consistent
-5. Always provide necessary information including instruction on how to duplicate the issue. Report such as "it doesn't work" will be ignored
-6. Duplicated issue will be closed
-7. Be responsible to find out what + Nemesis = issue
-8. Note that opening an issue is not equavilent to tech support ticket. We don't provide you tech support
-9. CBE is buggy in itself
-10. FNIS and Nemesis aren't compatible. Delete FNIS and the FNIS output to get your game to work
-11. Is it about TUDM, PCEA or something else other than Nemesis? Then don't report it here.
-12. Is anything broken for you? No, then ignore the warnings. Don't bother me with your "I got 1000 warnings" if everything is working fine
-13. Movement issues (dodging in place, no forward movement...) it can be due to a Nemesis issue. Nemesis will not always generate a animationdatasinglefile.txt and will instead edit an existing file in your load order .This file contains the motion data. After running Nemesis, search for the most recent animationdatasinglefile.txt in your load order. It is located in the meshes folder of behavior mods (CGO, SkySA, TUDM...). Most of the time FNIS mods won't contain some but you must verify. Once you have found it, copy and paste it in the meshes folder of the Nemesis output folder". This issue can never be solved by Nemesis as file management is not done by Nemesis
-14. Is the error message telling you to inform the "mod author"? If yes, then don't report to me, report it to the **MOD AUTHOR** not Nemesis' author!!! *Unless you are the mod author
-15. Program not launching? Check out [this issue](https://github.com/ShikyoKira/Project-New-Reign---Nemesis-Main/issues/211) and follow what's recommended by users there. I don't use windows 10 so I can't replicate it
-16. enquiry is not an issue. Google it or post on r/skyrimmods subreddit. Quite a number of people should be able to help answer your question
-17. Only post issue you face in the latest version. Any issue you aren't facing in the latest version but only in earlier version will be ignored
-18. "Does this work with Mod A?" Don't ask me. You test it
-19. Test the issue with or without mods. If it works without any mods, find out the culprit, only then open an issue with the culprit as the cause
-20. If you find it hard to put it into words, screenshot it
+1. remove all mods except essential mods to duplicate the issues as well as SKSE and alternate start and try to recreate the issue under this setup
+1. TUDM dodge not working? Are you using alternate start? if yes, get out of the cell
+1. Test test test. Make sure it is consistent
+1. Always provide necessary information including instruction on how to duplicate the issue. Report such as "it doesn't work" will be ignored
+1. Duplicated issue will be closed
+1. Be responsible to find out what + Nemesis = issue
+1. Note that opening an issue is not equavilent to tech support ticket. We don't provide you tech support
+1. CBE is buggy in itself
+1. FNIS and Nemesis aren't compatible. Delete FNIS and the FNIS output to get your game to work
+1. Is it about TUDM, PCEA or something else other than Nemesis? Then don't report it here.
+1. Is anything broken for you? No, then ignore the warnings. Don't bother me with your "I got 1000 warnings" if everything is working fine
+1. Movement issues (dodging in place, no forward movement...) it can be due to a Nemesis issue. Nemesis will not always generate a animationdatasinglefile.txt and will instead edit an existing file in your load order .This file contains the motion data. After running Nemesis, search for the most recent animationdatasinglefile.txt in your load order. It is located in the meshes folder of behavior mods (CGO, SkySA, TUDM...). Most of the time FNIS mods won't contain some but you must verify. Once you have found it, copy and paste it in the meshes folder of the Nemesis output folder". This issue can never be solved by Nemesis as file management is not done by Nemesis
+1. Is the error message telling you to inform the "mod author"? If yes, then don't report to me, report it to the **MOD AUTHOR** not Nemesis' author!!! *Unless you are the mod author
+1. Program not launching? Check out [this issue](https://github.com/ShikyoKira/Project-New-Reign---Nemesis-Main/issues/211) and follow what's recommended by users there. I don't use windows 10 so I can't replicate it
+1. enquiry is not an issue. Google it or post on r/skyrimmods subreddit. Quite a number of people should be able to help answer your question
+1. Only post issue you face in the latest version. Any issue you aren't facing in the latest version but only in earlier version will be ignored
+1. "Does this work with Mod A?" Don't ask me. You test it
+1. Test the issue with or without mods. If it works without any mods, find out the culprit, only then open an issue with the culprit as the cause
+1. If you find it hard to put it into words, screenshot it

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ What else?
 
 What's the catch?
 - With greater flexibility comes greater responsibility. Mod author and template author (Not Nemesis developer) will be responsible issue with the animation caused by their modification/template
-- Templates and patches have to be distributed under the same license (GLP) as this tool to ensure everyone enjoys the same benefits and contributions (Contact me @ShikyoKira personally if you don't want to)
+- Templates and patches have to be distributed under [the same license (GPL-3.0)](LICENSE) as this tool to ensure everyone enjoys the same benefits and contributions (Contact me @ShikyoKira personally if you don't want to)
 - With a better debugging system, users are required to do their own homework as well as trying to fix the issue themselves before bothering anyone, and provide necessary information in the event they have to ask someone for help
 
 
@@ -45,7 +45,7 @@ Youtube tutorial on how to use Nemesis: https://www.youtube.com/watch?v=mug-KFBw
 
 Build requirement for developers:
 - [Qt5](https://www.qt.io/download-open-source)
-- [boost](https://www.boost.org/users/download/) 
+- [boost](https://www.boost.org/users/download/)
 - [Python-3.5.6](https://www.python.org/downloads/release/python-356/) - Prebuilt binary version [here](https://drive.google.com/open?id=1Uqq0iQhc0qsWAiz3EFzqMWxB27BG-M5T)
 
 


### PR DESCRIPTION
When I read your Readme, I noticed a small typo in the license abbreviation and both fixed that and took the opportunity to turn it into a link to the LICENSE file in the repo (for those who want to know the details).

While I was at it, I also switched out the manual counting of your to-do-lists with the simple markdown-syntax for ordered lists.

This should make it a bit less tedious to add or remove entries in the future and offloads the counting to the markdown-interpreter, so it's less error-prone as well.

As the markdown-syntax could be a bit confusing to people reading the raw file though, I decided to put that into a seperate commit (ee7b05e1f40929b503063c6f5a16f4de2ab8acd3), so you could decide to omit merging that if you prefer the manual counting.